### PR TITLE
(feature) server: edit location of red-flag [finishes #162284833]

### DIFF
--- a/routes/redFlags.js
+++ b/routes/redFlags.js
@@ -62,5 +62,17 @@ router.post("/red-flags", (req, res) => {
 	res.status(200).json({status: 200, data: record});
 });
 
+// edit the location of a red flag record
+router.put("/red-flags/:id/location", (req, res) => {
+	//look up the course and validate
+	const record = records.find(c => c.id === parseInt(req.params.id));
+	//if invalid return 404
+	if (!record || (record.type !== "red-flag")) res.status(404).json({status: 404, error: "Record not a red-flag Entry. check ./red-flags for entry types"});
+	//else Update the course
+	else record.location = req.body.location;
+	//Return the updated course
+	res.status(200).json({status: 200, data: record});
+});
+
 
 module.exports = router;


### PR DESCRIPTION
### What does this PR do?
It implements an endpoint to edit the location of a red-flag records

### Description of Task to be completed?
PUT data to the endpoint PUT /api/v2/red-flags/:id

### How should this be manually tested?
1 launch Postman on chrome
2. access PUT http://localhost:3000/api/v2/red-flags/:id
3. edit a record and hit the send button

### What are the relevant pivotal tracker stories?
#162284833

